### PR TITLE
Chore: Download directory contains platform name

### DIFF
--- a/client/ayon_third_party/utils.py
+++ b/client/ayon_third_party/utils.py
@@ -46,7 +46,9 @@ if typing.TYPE_CHECKING:
 
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-DOWNLOAD_DIR = os.path.join(CURRENT_DIR, "downloads")
+DOWNLOAD_DIR = os.path.join(
+    CURRENT_DIR, "downloads", platform.system().lower()
+)
 NOT_SET = type("NOT_SET", (), {"__bool__": lambda: False})()
 IMPLEMENTED_ARCHIVE_FORMATS = {
     ".zip", ".tar", ".tgz", ".tar.gz", ".tar.xz", ".tar.bz2"


### PR DESCRIPTION
## Changelog Description
Platform name is part of download directory so shared folder can be used on any platform.

## Additional review information
When addons are stored to shared directory for multiple platforms, there won't happen clashes for different platforms.

## Testing notes:
1. Remove all third party addon versions from `%LOCALAPPDATA%\Ynput\AYON\addons\`.
2. Create package with this PR, upload to server and use in bundle.
3. Start AYON launcher.
4. OIIO and ffmpeg executables are downloaded into platform specific subfolder.
