### PR TITLE
Chore: Update ffmpeg to 7.1

### DIFF
--- a/create_package.py
+++ b/create_package.py
@@ -222,7 +222,9 @@ def download_oiio_archive(downloads_dir: str, log: logging.Logger):
         urllib.request.urlretrieve(src_url, archive_path)
         log.info("OIIO archive download - finished")
 
-        file_checksum = calculate_file_checksum(archive_path, checksum_algorithm)
+        file_checksum = calculate_file_checksum(
+            archive_path, checksum_algorithm
+        )
         if file_checksum != checksum:
             raise Exception(
                 f"OIIO archive checksum mismatch:"

--- a/create_package.py
+++ b/create_package.py
@@ -153,81 +153,83 @@ def calculate_file_checksum(filepath, hash_algorithm, chunk_size=10000):
     return hash_obj.hexdigest()
 
 
-def download_ffmpeg_zip(downloads_dir: str, log: logging.Logger):
-    zip_files_info = []
+def download_ffmpeg_archive(downloads_dir: str, log: logging.Logger):
+    archive_files_info = []
     for platform_name, platform_info in FFMPEG_SOURCES.items():
         src_url: str = platform_info["url"]
         filename: str = src_url.split("/")[-1]
-        zip_path: str = os.path.join(downloads_dir, filename)
+        archive_path: str = os.path.join(downloads_dir, filename)
         checksum: str = platform_info["checksum"]
         checksum_algorithm: str = platform_info["checksum_algorithm"]
-        zip_files_info.append({
+        archive_files_info.append({
             "name": "ffmpeg",
             "filename": filename,
             "checksum": checksum,
             "checksum_algorithm": checksum_algorithm,
             "platform": platform_name,
         })
-        if os.path.exists(zip_path):
+        if os.path.exists(archive_path):
             file_checksum: str = calculate_file_checksum(
-                zip_path, checksum_algorithm)
+                archive_path, checksum_algorithm)
             if checksum == file_checksum:
-                log.debug(f"FFmpeg zip from {src_url} already exists")
+                log.debug(f"FFmpeg archive from {src_url} already exists")
                 continue
-            os.remove(zip_path)
+            os.remove(archive_path)
 
-        log.debug(f"FFmpeg zip from {src_url} -> {zip_path}")
+        log.debug(f"FFmpeg archive from {src_url} -> {archive_path}")
 
-        log.info("FFmpeg zip download - started")
-        urllib.request.urlretrieve(src_url, zip_path)
-        log.info("FFmpeg zip download - finished")
+        log.info("FFmpeg archive download - started")
+        urllib.request.urlretrieve(src_url, archive_path)
+        log.info("FFmpeg archive download - finished")
 
         file_checksum = calculate_file_checksum(
-            zip_path, checksum_algorithm)
+            archive_path, checksum_algorithm)
 
         if checksum != file_checksum:
             raise Exception(
-                f"FFmpeg zip checksum mismatch: {file_checksum} != {checksum}"
+                f"FFmpeg archive checksum mismatch:"
+                f" {file_checksum} != {checksum}"
             )
 
-    return zip_files_info
+    return archive_files_info
 
 
-def download_oiio_zip(downloads_dir: str, log: logging.Logger):
-    zip_files_info = []
+def download_oiio_archive(downloads_dir: str, log: logging.Logger):
+    archive_files_info = []
     for platform_name, platform_info in OIIO_SOURCES.items():
         src_url: str = platform_info["url"]
         filename: str = src_url.split("/")[-1]
-        zip_path: str = os.path.join(downloads_dir, filename)
+        archive_path: str = os.path.join(downloads_dir, filename)
         checksum: str = platform_info["checksum"]
         checksum_algorithm: str = platform_info["checksum_algorithm"]
-        zip_files_info.append({
+        archive_files_info.append({
             "name": "oiio",
             "filename": filename,
             "checksum": checksum,
             "checksum_algorithm": checksum_algorithm,
             "platform": platform_name
         })
-        if os.path.exists(zip_path):
+        if os.path.exists(archive_path):
             file_checksum = calculate_file_checksum(
-                zip_path, checksum_algorithm)
+                archive_path, checksum_algorithm)
             if checksum == file_checksum:
-                log.debug(f"OIIO zip from {src_url} already exists")
+                log.debug(f"OIIO archive from {src_url} already exists")
                 continue
-            os.remove(zip_path)
-        log.debug(f"OIIO zip from {src_url} -> {zip_path}")
+            os.remove(archive_path)
+        log.debug(f"OIIO archive from {src_url} -> {archive_path}")
 
-        log.info("OIIO zip download - started")
-        urllib.request.urlretrieve(src_url, zip_path)
-        log.info("OIIO zip download - finished")
+        log.info("OIIO archive download - started")
+        urllib.request.urlretrieve(src_url, archive_path)
+        log.info("OIIO archive download - finished")
 
-        file_checksum = calculate_file_checksum(zip_path, checksum_algorithm)
+        file_checksum = calculate_file_checksum(archive_path, checksum_algorithm)
         if file_checksum != checksum:
             raise Exception(
-                f"OIIO zip checksum mismatch: {file_checksum} != {checksum}"
+                f"OIIO archive checksum mismatch:"
+                f" {file_checksum} != {checksum}"
             )
 
-    return zip_files_info
+    return archive_files_info
 
 
 def _get_yarn_executable() -> Union[str, None]:
@@ -527,8 +529,8 @@ def main(
     downloads_dir = os.path.join(CURRENT_ROOT, "downloads")
     os.makedirs(downloads_dir, exist_ok=True)
 
-    ffmpeg_files_info = download_ffmpeg_zip(downloads_dir, log)
-    oiio_files_info = download_oiio_zip(downloads_dir, log)
+    ffmpeg_files_info = download_ffmpeg_archive(downloads_dir, log)
+    oiio_files_info = download_oiio_archive(downloads_dir, log)
     files_info = ffmpeg_files_info + oiio_files_info
 
     files_info_stream = io.BytesIO(json.dumps(files_info).encode())

--- a/create_package.py
+++ b/create_package.py
@@ -39,26 +39,26 @@ from typing import Optional, Iterable, Pattern, Union, List, Tuple
 
 import package
 
-DISTRIBUTE_SOURCE_URL: str = "https://distribute.openpype.io/thirdparty"
+DISTRIBUTE_SOURCE_URL: str = "https://distribute.ynput.io/thirdparty"
 FFMPEG_SOURCES = {
     "windows": {
-        "url": f"{DISTRIBUTE_SOURCE_URL}/ffmpeg-4.4-windows-2.zip",
+        "url": f"{DISTRIBUTE_SOURCE_URL}/ffmpeg-7.1-windows.tar.xz",
         "checksum": (
-            "5f09109c96a3e53beec042e969653716324b467c66788807e69e81c233e19d20"
+            "3d2b824136748319cc11d6d2cd99e932338ed50d851818e7b4069cd92e19992d"
         ),
         "checksum_algorithm": "sha256",
     },
     "linux": {
-        "url": f"{DISTRIBUTE_SOURCE_URL}/ffmpeg-4.4-linux.tgz",
+        "url": f"{DISTRIBUTE_SOURCE_URL}/ffmpeg-7.1-linux.tar.xz",
         "checksum": (
-            "10b9beda57cfbb69b9ed0ce896c0c8d99227b26ca8b9f611040c4752e365cbe9"
+            "ec85a3245bcda68379a356a3a8879af272f51297cb8ff9067dc82a0ae27b80d6"
         ),
         "checksum_algorithm": "sha256",
     },
     "darwin": {
-        "url": f"{DISTRIBUTE_SOURCE_URL}/ffmpeg-4.4-macos.tgz",
+        "url": f"{DISTRIBUTE_SOURCE_URL}/ffmpeg-7.1-macos-intel.tar.xz",
         "checksum": (
-            "95f43568338c275f80dc0cab1e1836a2e2270f856f0e7b204440d881dd74fbdb"
+            "4ed7a974a77ff2766f1e4e6abf08de351c9ce41b594def5c8ba4da315c5ce655"
         ),
         "checksum_algorithm": "sha256",
     }


### PR DESCRIPTION
## Changelog Description
Updated ffmpeg to 7.1 and use ynput distribution url.

## Testing notes:
1. Create and upload package, then use it in bundle.
2. Start AYON launcher.
3. New version of ffmpeg should be downloaded.
