### PR TITLE
Chore: Enhanced download and extraction of files

### DIFF
--- a/client/ayon_third_party/utils.py
+++ b/client/ayon_third_party/utils.py
@@ -359,6 +359,11 @@ def _get_addon_endpoint() -> str:
 
 
 def _get_resources_dir(*args) -> str:
+    # TODO use helper function from ayon-core for resources directory
+    #   when implemented in ayon-core addon.
+    addons_resources_dir = os.getenv("AYON_ADDONS_RESOURCES_DIR")
+    if addons_resources_dir:
+        return os.path.join(addons_resources_dir, ADDON_NAME, *args)
     return get_launcher_storage_dir(
         "addons_resources", ADDON_NAME, *args
     )
@@ -371,8 +376,6 @@ def _get_info_path(name: str) -> str:
         return get_launcher_storage_dir(
             "addons", f"{ADDON_NAME}-{name}.json"
         )
-    # TODO use addons resources directory when implemented in AYON launcher
-    #   and ayon-core
     return _get_resources_dir(f"{name}.json")
 
 

--- a/client/ayon_third_party/utils.py
+++ b/client/ayon_third_party/utils.py
@@ -270,13 +270,27 @@ def get_addon_settings():
     return copy.deepcopy(_ThirdPartyCache.addon_settings.get_data())
 
 
+def _makedirs(path: str):
+    """Create directory if not exists.
+
+    Do not execute 'os.makedirs' if directory already exists, to avoid
+    possible permissions issues.
+
+    Args:
+        path (str): Directory that should be created.
+
+    """
+    if not os.path.exists(path):
+        os.makedirs(path, exist_ok=True)
+
+
 def _get_download_dir(create_if_missing: bool = True) -> str:
     """Dir path where files are downloaded.
 
     DEPRECATED: Use relative path to addon resource dirs.
     """
     if create_if_missing:
-        os.makedirs(_DEPRECATED_DOWNLOAD_DIR, exist_ok=True)
+        _makedirs(_DEPRECATED_DOWNLOAD_DIR)
     return _DEPRECATED_DOWNLOAD_DIR
 
 
@@ -376,7 +390,7 @@ def _filter_file_info(name: str) -> List["ToolInfo"]:
 def _store_file_info(name: str, info: List["ToolInfo"]):
     filepath = _get_info_path(name)
     root, filename = os.path.split(filepath)
-    os.makedirs(root, exist_ok=True)
+    _makedirs(root)
     with open(filepath, "w") as stream:
         json.dump(info, stream)
 
@@ -763,7 +777,7 @@ def _download_file(
 
         # Store checksum so any future processes know that this was
         # downloaded and extracted
-        os.makedirs(dirpath, exist_ok=True)
+        _makedirs(dirpath)
         progress_info = {"state": "extracting"}
         with open(progress_path, "w") as stream:
             json.dump(progress_info, stream)

--- a/client/ayon_third_party/utils.py
+++ b/client/ayon_third_party/utils.py
@@ -16,7 +16,7 @@ from typing import Optional, Tuple, List, Dict, Any
 import ayon_api
 from ayon_api import TransferProgress
 
-from ayon_core.lib import Logger
+from ayon_core.lib import Logger, CacheItem
 try:
     from ayon_core.lib import get_launcher_storage_dir
 except ImportError:
@@ -92,7 +92,7 @@ class _FFmpegArgs:
 
 
 class _ThirdPartyCache:
-    addon_settings = NOT_SET
+    addon_settings = CacheItem(lifetime=60)
 
 
 class ZipFileLongPaths(zipfile.ZipFile):
@@ -261,11 +261,13 @@ def extract_archive_file(
 
 
 def get_addon_settings():
-    if _ThirdPartyCache.addon_settings is NOT_SET:
-        _ThirdPartyCache.addon_settings = ayon_api.get_addon_settings(
-            ADDON_NAME, __version__
+    if not _ThirdPartyCache.addon_settings.is_valid:
+        _ThirdPartyCache.addon_settings.update_data(
+            ayon_api.get_addon_settings(
+                ADDON_NAME, __version__
+            )
         )
-    return copy.deepcopy(_ThirdPartyCache.addon_settings)
+    return copy.deepcopy(_ThirdPartyCache.addon_settings.get_data())
 
 
 def _get_download_dir(create_if_missing: bool = True) -> str:


### PR DESCRIPTION
## Changelog Description
Overall enhancement of files download and extraction.

## Additional review information
Most of changes are related to clashes when multiple processes, machines, users start to download same files. Files are not downloaded directly to target directory but to temp folder first. There is added progress file to target extraction folder to find out if is ok-ish to extract content. The file content is simple json with "state" value.

Additionally the download content is not stored to addon in `addons` directory, but to `{AYON_LAUNCHER_STORAGE_DIR}/addons_resouces/ayon_third_party/` directory (we should define this directory in launcher and add helper functions into ayon-core). This currently happens only for ffmpeg which updated version with https://github.com/ynput/ayon-third-party/pull/24 so we can introduce new download logic without affecting previous 3rd party addon versions and handling backwards compatibility.

## Testing notes:
1. Look at the code changes if they make sense...
2. Create package, upload to server, use in bundle.
3. If multiple processes of AYON started at once, they should be able to handle extraction of new ffmpeg binaries without any clashes. (they might each download it but extraction should not clash)