### PR TITLE
Chore: Update 'state' variable in distribution wait logic

### DIFF
--- a/client/ayon_third_party/utils.py
+++ b/client/ayon_third_party/utils.py
@@ -688,6 +688,7 @@ def _wait_for_other_process(progress_path: str, progress_id: str):
         if current_state != state:
             started = time.time()
             threshold_time = None
+            state = current_state
 
         if threshold_time is None:
             threshold_time = EXTRACT_WAIT_TRESHOLD_TIME

--- a/client/ayon_third_party/utils.py
+++ b/client/ayon_third_party/utils.py
@@ -700,7 +700,14 @@ def _wait_for_other_process(progress_path: str, progress_id: str):
                 f"Waited for treshold time ({EXTRACT_WAIT_TRESHOLD_TIME}s)."
                 f" Extracting downloaded content."
             )
-            shutil.rmtree(dirpath)
+            try:
+                shutil.rmtree(dirpath)
+            except PermissionError as exc:
+                log.warning(
+                    "Failed to remove target directory. Other process"
+                    " might still be extracting content."
+                )
+                raise exc
             break
         time.sleep(0.1)
     return False


### PR DESCRIPTION
## Changelog Description
Avoid infinite loop if distribution file already exists.

## Additional review information
If distribution metadata file exists with wrong state, the other process ends up in infinite loop, instead of taking over the download progress.

## Testing notes:
1. Let 3rd party addon download ffmpeg and oiio.
2. Close AYON.
3. Go to addons resources directory (`%LOCALAPPDATA%\Ynput\AYON\addons_resources\ayon_third_party`).
4. Choose on of the subfolders there (ffmpeg of oiio) and modify `dist_progress.json` to have `"state"` as `"downloading"` (fake broken distribution).
5. Start AYON, it should show downloading window, and after at about 20 seconds start to download the binary again.