### PR TITLE
CI: Fix Mkdocs Automation

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -1,0 +1,20 @@
+name: Deploy MkDocs
+
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - "bugfix/38-fix-mkdocs-ci"
+  workflow_dispatch:
+
+jobs:
+  build-mk-docs:
+    # FIXME: Update @develop to @main after `ops-repo-automation` release.
+    uses: ynput/ops-repo-automation/.github/workflows/deploy_mkdocs.yml@develop
+    with:
+      repo: ${{ github.repository }}
+    secrets:
+      YNPUT_BOT_TOKEN: ${{ secrets.YNPUT_BOT_TOKEN }}
+      CI_USER: ${{ secrets.CI_USER }}
+      CI_EMAIL: ${{ secrets.CI_EMAIL }}

--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - "bugfix/38-fix-mkdocs-ci"
   workflow_dispatch:
 
 jobs:

--- a/create_package.py
+++ b/create_package.py
@@ -153,6 +153,29 @@ class ZipFileLongPaths(zipfile.ZipFile):
         return super()._extract_member(member, tpath, pwd)
 
 
+def update_pyproject_version(logger):
+    pyproject_toml = os.path.join(CURRENT_ROOT, "pyproject.toml")
+    if not os.path.exists(pyproject_toml):
+        logger.info("Did not find pyproject.toml in root directory. Skipping")
+        return
+
+    line_idx = None
+    new_lines = []
+    with open(pyproject_toml, "r", encoding="utf-8") as stream:
+        for idx, line in enumerate(stream.readlines()):
+            if line_idx is None and line.startswith("version"):
+                line_idx = idx
+            new_lines.append(line)
+
+    if line_idx is None:
+        logger.info("Failed to find version in pyproject.toml. Skipping.")
+        return
+
+    new_lines[line_idx] = f"version = \"{ADDON_VERSION}\"\n"
+    with open(pyproject_toml, "w", encoding="utf-8") as stream:
+        stream.write("".join(new_lines))
+
+
 def calculate_file_checksum(filepath, hash_algorithm, chunk_size=10000):
     """Calculate file checksum.
 
@@ -548,6 +571,8 @@ def main(
 ):
     log: logging.Logger = logging.getLogger("create_package")
     log.info("Package creation started")
+
+    update_pyproject_version(log)
 
     downloads_dir = os.path.join(CURRENT_ROOT, "downloads")
     os.makedirs(downloads_dir, exist_ok=True)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,12 +11,12 @@ theme:
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       toggle:
-        icon: material/toggle-switch-off-outline
+        icon: material/weather-sunny
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
       toggle:
-        icon: material/toggle-switch
+        icon: material/weather-night
         name: Switch to dark mode
   logo: img/ay-symbol-blackw-full.png
   favicon: img/favicon.ico

--- a/mkdocs_requirements.txt
+++ b/mkdocs_requirements.txt
@@ -1,0 +1,9 @@
+mkdocs-material >= 9.6.7
+mkdocs-autoapi >= 0.4.0
+mkdocstrings-python >= 1.16.2
+mkdocs-minify-plugin >= 0.8.0
+markdown-checklist >= 0.4.4
+mdx-gh-links >= 0.4
+pymdown-extensions >= 10.14.3
+mike >= 2.1.3
+mkdocstrings-shell >= 1.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 
 [project]
 name = "ayon-third-party"
+version = "1.4.0+dev"
 description = "Third party addon for Ayon.\n"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,22 +2,10 @@
 
 [project]
 name = "ayon-third-party"
-version = "1.2.0"
 description = "Third party addon for Ayon.\n"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "tomlkit>=0.13.2",
-    "requests>=2.32.3",
-    "mkdocs-material>=9.6.7",
-    "mkdocs-autoapi>=0.4.0",
-    "mkdocstrings-python>=1.16.2",
-    "mkdocstrings-shell>=1.0.2",
-    "mkdocs-minify-plugin>=0.8.0",
-    "markdown-checklist>=0.4.4",
-    "mdx-gh-links>=0.4",
-    "pymdown-extensions>=10.14.3",
-    "mike>=2.1.3",
     "pytest>=8.3.5",
 ]
 


### PR DESCRIPTION
## Changelog Description
- Add a CI action to trigger MK Docs deployment on creating new tags.
when testing the CI action manually (trigger from Action tab manually on GH), it will generate a `dummy-build` version that will be deleted as soon as a tag is created.
- Revert changes to `pyproject.toml` from #29 as they are no longer needed for current mkdocs.

resolve #38 

## Additional Notes
This PR ports https://github.com/ynput/ayon-core/pull/1441 fixes for applications addon.
This PR add some cosmetics: 
1. update light and dark mode icons. 
2. move requirements file to root location of the repo to avoid moving it along with the docs build.

## Testing notes:
1. go to https://docs.ayon.dev/ayon-third-party/latest/ you should find light/dark icons are updated and the latest is pointing to `test-build`.
since the workflow doesn't exist in main branch yet, I had to add on push temporarily in 9b75ddee9e2cf524d9b225ebca2dfcda8651e7e2 to run the action and revert it in https://github.com/ynput/ayon-third-party/pull/39/commits/386a82d99663dbf7ea3dbbb7e8de824a7be5a75b.